### PR TITLE
Clarify which chunk needs to be free

### DIFF
--- a/diving_into_glibc_heap/malloc_chunk.md
+++ b/diving_into_glibc_heap/malloc_chunk.md
@@ -4,12 +4,12 @@ This structure represents a particular chunk of memory. The various fields have 
 
 ```c
 struct malloc_chunk {
-  INTERNAL_SIZE_T      mchunk_prev_size;  /* Size of previous chunk (if free).  */
+  INTERNAL_SIZE_T      mchunk_prev_size;  /* Size of previous chunk, if it is free. */
   INTERNAL_SIZE_T      mchunk_size;       /* Size in bytes, including overhead. */
-  struct malloc_chunk* fd;                /* double links -- used only if free. */
+  struct malloc_chunk* fd;                /* double links -- used only if this chunk is free. */
   struct malloc_chunk* bk;
   /* Only used for large blocks: pointer to next larger size.  */
-  struct malloc_chunk* fd_nextsize; /* double links -- used only if free. */
+  struct malloc_chunk* fd_nextsize; /* double links -- used only if this chunk is free. */
   struct malloc_chunk* bk_nextsize;
 };
 


### PR DESCRIPTION
The "free"-condition of `mchunk_prev_size` and chunk pointers apply to different subjects. This was confusing for someone without prior knowledge. Properly indicating the sentence's subject should clear things up.